### PR TITLE
v1.3.0 feat: make TODO impact level configurable via settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "linear-todos" extension will be documented in this f
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.0] - 2026-05-29
+
+### Added
+- ⚙️ `linearTodos.defaultImpact` setting to control the impact level applied when creating an issue. Set it to `high`, `medium`, or `low` to skip the impact prompt entirely and always use that priority; leave it on `ask` (default) to keep being prompted each time.
+
+### Changed
+- Creating an issue no longer forces you through the impact picker when a default impact is configured.
+
 ## [1.0.0] - 2024-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A VSCode extension that converts TODO comments into Linear issues with full code
 - `linearTodos.teamId`: Default Linear team ID (optional)
 - `linearTodos.autoHighlight`: Enable TODO highlighting (default: true)
 - `linearTodos.showStatusBar`: Show TODO count in status bar (default: true)
+- `linearTodos.defaultImpact`: Impact level applied when creating an issue — `ask` (default, prompts each time) or `high`/`medium`/`low` to skip the prompt and always use that priority
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Linear TODOs",
 	"description": "Manage TODOs and tech debt by creating Linear issues directly from code comments",
 	"icon": "/assets/icon.png",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"publisher": "DanTran",
 	"repository": {
 		"type": "git",
@@ -83,6 +83,23 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show TODO count in status bar"
+				},
+				"linearTodos.defaultImpact": {
+					"type": "string",
+					"enum": [
+						"ask",
+						"high",
+						"medium",
+						"low"
+					],
+					"enumDescriptions": [
+						"Prompt for impact each time an issue is created",
+						"Always create issues as High priority (no prompt)",
+						"Always create issues as Medium priority (no prompt)",
+						"Always create issues as Low priority (no prompt)"
+					],
+					"default": "ask",
+					"description": "Impact level applied when creating a Linear issue from a TODO. Set to a fixed level to skip the impact prompt."
 				}
 			}
 		},

--- a/src/linear_service.ts
+++ b/src/linear_service.ts
@@ -99,8 +99,8 @@ export class LinearService {
 			}
 		}
 
-		// Prompt user for impact level
-		const impact = await this.promptForImpact();
+		// Resolve impact level: prompt the user, or use the configured default
+		const impact = await this.resolveImpact();
 		if (!impact) {
 			// User cancelled
 			return null;
@@ -304,6 +304,24 @@ export class LinearService {
 		// Extract just the filename from the path
 		const parts = filePath.split("/");
 		return parts[parts.length - 1];
+	}
+
+	private async resolveImpact(): Promise<string | null> {
+		const config = vscode.workspace.getConfiguration("linearTodos");
+		const defaultImpact = config.get<string>("defaultImpact", "ask");
+
+		// "ask" (the default) preserves the prompt-on-every-create behavior.
+		// Any other value skips the prompt and uses that fixed impact.
+		switch (defaultImpact) {
+			case "high":
+				return "High - Critical issue affecting functionality or security";
+			case "medium":
+				return "Medium - Standard improvement or technical debt";
+			case "low":
+				return "Low - Minor enhancement or polish";
+			default:
+				return this.promptForImpact();
+		}
 	}
 
 	private async promptForImpact(): Promise<string | null> {


### PR DESCRIPTION
## Summary
Addresses #4 — users no longer have to specify a criticality/impact level on every issue creation.

Adds a new setting **`linearTodos.defaultImpact`** (`ask` | `high` | `medium` | `low`, default `ask`):
- Leave it on `ask` (default) → current behavior, the impact QuickPick appears each time. Zero change for existing users.
- Set a fixed level (`high`/`medium`/`low`) → the prompt is skipped entirely and that Linear priority is always used.

This is a superset of the two options the reporter suggested (remove the step *or* make it configurable): the step becomes removable per-user via settings, while staying available for anyone who wants it.

**Changes**
- `src/linear_service.ts` — new `resolveImpact()` reads the setting and either prompts (`ask`) or returns the fixed impact. `promptForImpact()` and the priority mapping are unchanged. Any unrecognized value falls through to the prompt (fail-safe).
- `package.json` — declares `linearTodos.defaultImpact` (enum + `enumDescriptions`), version → 1.3.0.
- `README.md` — documents the setting.
- `CHANGELOG.md` — 1.3.0 entry.

## Test Coverage
No automated test suite exists beyond the sample `vscode-test` placeholder, so no unit tests were added. Verified manually:
- `npm run lint` — clean
- `npx tsc -p . --noEmit` — clean
- `npm run compile` (webpack) — builds (1 pre-existing warning: optional `encoding` dep in `@linear/sdk`, unrelated)

New code paths (all covered by the switch in `resolveImpact`): `ask` → prompt; `high`/`medium`/`low` → fixed impact; unknown → prompt fallback.

## Pre-Landing Review
38-line diff, no issues found. No SQL, no LLM trust boundary, no new external surface. Enum values in `package.json` match the switch cases.

## Design Review
No frontend files changed — design review skipped.

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [x] Webpack build succeeds
- [ ] Manual: set `linearTodos.defaultImpact` to `medium`, create an issue from a TODO, confirm no prompt and Medium priority on the Linear issue
- [ ] Manual: set back to `ask`, confirm the impact picker reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)